### PR TITLE
bugfix: Display should show name of special day

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name="sleepcounter",
-    version="1.0.3",
+    version="1.0.4",
     packages=find_packages(),
     install_requires=[
         'linearstage==0.2.0',

--- a/sleepcounter/__main__.py
+++ b/sleepcounter/__main__.py
@@ -7,7 +7,7 @@ from linearstage.config import STAGE_CONFIG
 from sleepcounter.controller import Controller
 from sleepcounter.time.calendar import Calendar
 from sleepcounter.time.datelibrary import DateLibrary
-from sleepcounter.widget.display import LedMatrixWidget
+from sleepcounter.widget.display import LedMatrixWidget, create_default_display
 from linearstage.stage import Stage
 from sleepcounter.widget.stage import SleepsStageWidget
 
@@ -18,12 +18,13 @@ logging.basicConfig(
 
 calendar = Calendar(DateLibrary(
     {
-        'Christmas': datetime(2018, 12, 25),
-        'New Years Day': datetime(2019, 1, 1),
+        'Christmas': datetime(2018, 12, 25).date(),
+        'New Years Day': datetime(2019, 1, 1).date(),
     }
 ))
 controller = Controller(calendar)
-controller.register_widget(LedMatrixWidget())
+controller.register_widget(
+    LedMatrixWidget(create_default_display()))
 controller.register_widget(
     SleepsStageWidget(Stage.from_config(STAGE_CONFIG)))
 

--- a/sleepcounter/mocks/datetime.py
+++ b/sleepcounter/mocks/datetime.py
@@ -1,0 +1,19 @@
+import datetime
+from unittest.mock import patch
+
+def mock_datetime(target):
+
+    class MockedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return target.replace(tzinfo=tz)
+
+        @classmethod
+        def utcnow(cls):
+            return target
+
+        @classmethod
+        def today(cls):
+            return target
+
+    return patch.object(datetime, 'datetime', MockedDatetime)

--- a/sleepcounter/mocks/stage.py
+++ b/sleepcounter/mocks/stage.py
@@ -1,25 +1,4 @@
-import datetime
-from unittest.mock import patch
-
 from linearstage.stage import OutOfRangeError
-
-
-def mock_datetime(target):
-
-    class MockedDatetime(datetime.datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return target.replace(tzinfo=tz)
-
-        @classmethod
-        def utcnow(cls):
-            return target
-
-        @classmethod
-        def today(cls):
-            return target
-
-    return patch.object(datetime, 'datetime', MockedDatetime)
 
 
 class MockStage:

--- a/sleepcounter/time/test/test_calendar.py
+++ b/sleepcounter/time/test/test_calendar.py
@@ -4,7 +4,7 @@ import unittest
 
 from sleepcounter.time.calendar import Calendar
 from sleepcounter.time.datelibrary import DateLibrary
-from sleepcounter.test.utils import mock_datetime
+from sleepcounter.mocks.datetime import mock_datetime
 
 # TODO: same date every year
 BONFIRE_NIGHT = datetime.date(2018, 11, 5)

--- a/sleepcounter/widget/display.py
+++ b/sleepcounter/widget/display.py
@@ -7,34 +7,50 @@ from sleepcounter.widget.base import BaseWidget
 
 LOGGER = logging.getLogger("display widget") 
 
-
-display = matrix(cascaded=4)
-# we need to create display then set speed and then recreate so that spped is
-# correct when needed.# better would be to create the spi instance and pass this
-# into the constructor to instantiate matrix
-display._spi.max_speed_hz = 7800000
-display = matrix(cascaded=4)
-display.orientation(90)
-display.brightness(2)
-display.clear()
-display.show_message('Ready')
+def create_default_display():
+    display = matrix(cascaded=4)
+    # we need to create display then set speed and then recreate so that spped
+    # is correct when needed.# better would be to create the spi instance and
+    # pass this into the constructor to instantiate matrix
+    display._spi.max_speed_hz = 7800000
+    display = matrix(cascaded=4)
+    display.orientation(90)
+    display.brightness(2)
+    display.clear()
+    display.show_message('Ready')
+    return display
 
 
 class LedMatrixWidget(BaseWidget):
     """
     Represents the date using an led matrix. 
     """
-    def __init__(self):
+    def __init__(self, display):
         LOGGER.info("Intantiating")
+        self.display = display
         
     def update(self, calendar):
+        if calendar.special_day_today:
+            self._handle_special_day(calendar)
+        else:
+            self._handle_regular_day(calendar)
+
+    def _handle_special_day(self, calendar):
+        msg = "It's {}!".format(calendar.todays_event)
+        LOGGER.info(
+            "Updating with calendar {}. Setting message to {}"
+            .format(calendar, msg))
+        self.display.clear()       
+        self.display.show_message(msg)
+    
+    def _handle_regular_day(self, calendar):
         sleeps = calendar.sleeps_to_next_event
         msg = "{} in {} sleeps".format(
             calendar.next_event, sleeps)
         LOGGER.info(
             "Updating with calendar {}. Setting message to {}"
             .format(calendar, msg))
-        display.clear()       
-        display.show_message(msg)
+        self.display.clear()       
+        self.display.show_message(msg)
         LOGGER.info("Setting message to {}".format(sleeps))
-        display.show_message(str(sleeps))
+        self.display.show_message(str(sleeps))

--- a/sleepcounter/widget/test/test_display.py
+++ b/sleepcounter/widget/test/test_display.py
@@ -1,0 +1,65 @@
+import datetime
+import logging
+import os
+import unittest
+from unittest.mock import Mock, patch, call
+
+from sleepcounter.time.calendar import Calendar, _WAKE_UP_TIME
+from sleepcounter.time.datelibrary import DateLibrary
+################# patch hardware specific modules before import ################
+import sys
+# # This only seems to work in python 3.7
+sys.modules['max7219.led'] = Mock()
+################################################################################
+from sleepcounter.mocks.datetime import mock_datetime
+from sleepcounter.widget.display import LedMatrixWidget
+
+logging.basicConfig(
+    format='%(asctime)s[%(name)s]:%(levelname)s:%(message)s',
+    stream=sys.stdout,
+    level=logging.INFO)
+
+CHRISTMAS_DAY = datetime.datetime(2018, 12, 25)
+NEW_YEARS_DAY = datetime.datetime(2019, 1, 1)
+CALENDAR = Calendar(DateLibrary(
+    {
+        'Christmas': CHRISTMAS_DAY.date(),
+        'New Years Day': NEW_YEARS_DAY.date(),
+    }
+))
+
+
+class TestBase(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_matrix = Mock()
+        self.display = LedMatrixWidget(self.mock_matrix)
+
+    def tearDown(self):
+        pass
+
+
+class DisplayUpdateTests(TestBase):
+
+    def test_display_shows_correct_sleeps(self):
+        today = datetime.datetime(
+            year=2018,
+            month=12,
+            day=23,
+            hour=12,
+            minute=10)
+        expected_sleeps = 2
+        with mock_datetime(target=today):
+            self.display.update(CALENDAR)
+        self.mock_matrix.show_message.assert_called_with(str(expected_sleeps))
+
+    def test_display_shows_special_day(self):
+        today = datetime.datetime(
+            year=2018,
+            month=12,
+            day=25,
+            hour=17,
+            minute=9)
+        with mock_datetime(target=today):
+            self.display.update(CALENDAR)
+        self.mock_matrix.show_message.assert_called_with("It's Christmas!")

--- a/sleepcounter/widget/test/test_stage.py
+++ b/sleepcounter/widget/test/test_stage.py
@@ -13,7 +13,8 @@ from sleepcounter.widget.stage import (
     DEFAULT_RECOVERY_FILE)
 ################################################################################
 
-from sleepcounter.test.utils import MockStage, mock_datetime
+from sleepcounter.mocks.datetime import mock_datetime
+from sleepcounter.mocks.stage import MockStage
 from sleepcounter.time.calendar import Calendar
 from sleepcounter.time.datelibrary import DateLibrary
 


### PR DESCRIPTION
On a special day, the display widget fails to show the name of the event/day.
Bug is fixed in this commit.