### PR TITLE
Bugfix: should display sleeps plural or singular

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 setup(
     name="sleepcounter",
-    version="1.0.4",
+    version="1.0.5",
     packages=find_packages(),
     install_requires=[
         'linearstage==0.2.0',

--- a/sleepcounter/widget/display.py
+++ b/sleepcounter/widget/display.py
@@ -45,8 +45,9 @@ class LedMatrixWidget(BaseWidget):
     
     def _handle_regular_day(self, calendar):
         sleeps = calendar.sleeps_to_next_event
-        msg = "{} in {} sleeps".format(
-            calendar.next_event, sleeps)
+        unit = 'sleeps' if sleeps > 1 else 'sleep'
+        msg = "{} in {} {}".format(
+            calendar.next_event, sleeps, unit)
         LOGGER.info(
             "Updating with calendar {}. Setting message to {}"
             .format(calendar, msg))

--- a/sleepcounter/widget/test/test_display.py
+++ b/sleepcounter/widget/test/test_display.py
@@ -52,6 +52,22 @@ class DisplayUpdateTests(TestBase):
         with mock_datetime(target=today):
             self.display.update(CALENDAR)
         self.mock_matrix.show_message.assert_called_with(str(expected_sleeps))
+        self.assertTrue(call('Christmas in {} sleeps'.format(expected_sleeps))
+            in self.mock_matrix.show_message.call_args_list)
+
+    def test_display_shows_one_sleep(self):
+        today = datetime.datetime(
+            year=2018,
+            month=12,
+            day=24,
+            hour=12,
+            minute=10)
+        expected_sleeps = 1
+        with mock_datetime(target=today):
+            self.display.update(CALENDAR)
+        self.mock_matrix.show_message.assert_called_with(str(expected_sleeps))
+        self.assertTrue(call('Christmas in 1 sleep') in 
+            self.mock_matrix.show_message.call_args_list)
 
     def test_display_shows_special_day(self):
         today = datetime.datetime(


### PR DESCRIPTION
Sleepcounter display shows 1 sleep and x sleeps when required - not 1 sleeps.